### PR TITLE
Opraveno z CLI na CIL

### DIFF
--- a/_posts/2021-02-19-the-cs-programming-language.md
+++ b/_posts/2021-02-19-the-cs-programming-language.md
@@ -482,7 +482,7 @@ class File {
 }
 ```
 
-### CLI Type System
+### CIL Type System
 - compared to C++, we can't choose whether something is a value or a reference -- it is determined by its type
 
 #### Value types


### PR DESCRIPTION
Vim, ze Jezek ma ve svych prezentacich take CLI, ale myslim, ze CIL (Common Intermediate Language) je spravne.